### PR TITLE
When the input is an empty string, `setInput()` will be executed

### DIFF
--- a/denops/ddu/app.ts
+++ b/denops/ddu/app.ts
@@ -82,7 +82,7 @@ export async function main(denops: Denops) {
 
       const ddu = getDdu(name);
 
-      if (opt?.input) {
+      if (opt.input != null) {
         ddu.setInput(opt.input);
       }
 


### PR DESCRIPTION
`setInput()` was not being executed when the input was empty.
So if the filter string is empty, the candidates will not be restored.