### PR TITLE
Call redraw() on first enqueue

### DIFF
--- a/denops/ddu/ddu.ts
+++ b/denops/ddu/ddu.ts
@@ -211,11 +211,11 @@ export class Ddu {
         // Update items
         if (state.items.length != 0) {
           state.items = state.items.concat(newItems);
-          if (!this.finished) {
-            await this.redraw(denops);
-          }
         } else {
           state.items = newItems;
+        }
+        if (!this.finished) {
+          await this.redraw(denops);
         }
 
         reader.read().then(readChunk);


### PR DESCRIPTION
When the source calls `controller.enqueue()` multiple times such as `Ddu file_rec` in large directory, the ui is not shown on first enqueue.