### PR TITLE
Add preview interface

### DIFF
--- a/autoload/ddu.vim
+++ b/autoload/ddu.vim
@@ -22,6 +22,9 @@ endfunction
 function! ddu#expand_item(name, item) abort
   return ddu#_notify('expandItem', [a:name, a:item])
 endfunction
+function! ddu#get_previewer(name, item, params, context) abort
+  return ddu#_request('getPreviewer', [a:name, a:item, a:params, a:context])
+endfunction
 
 function! ddu#_request(method, args) abort
   if s:init()

--- a/denops/ddu/app.ts
+++ b/denops/ddu/app.ts
@@ -226,7 +226,7 @@ export async function main(denops: Denops) {
       arg1: unknown,
       arg2: unknown,
       arg3: unknown,
-    ): Promise<Previewer> {
+    ): Promise<Previewer | undefined> {
       const name = ensureString(arg1);
       const items = ensureObject(arg2) as DduItem;
       const actionParams = ensureObject(arg3);

--- a/denops/ddu/app.ts
+++ b/denops/ddu/app.ts
@@ -11,6 +11,7 @@ import {
   DduExtType,
   DduItem,
   DduOptions,
+  PreviewContext,
   Previewer,
 } from "./types.ts";
 import { Ddu } from "./ddu.ts";
@@ -226,12 +227,19 @@ export async function main(denops: Denops) {
       arg1: unknown,
       arg2: unknown,
       arg3: unknown,
+      arg4: unknown,
     ): Promise<Previewer | undefined> {
       const name = ensureString(arg1);
       const items = ensureObject(arg2) as DduItem;
-      const actionParams = ensureObject(arg3);
+      const actionParams = arg3;
+      const previewContext = ensureObject(arg4) as PreviewContext;
       const ddu = getDdu(name);
-      return await ddu.getPreviewer(denops, items, actionParams);
+      return await ddu.getPreviewer(
+        denops,
+        items,
+        actionParams,
+        previewContext,
+      );
     },
   };
 

--- a/denops/ddu/app.ts
+++ b/denops/ddu/app.ts
@@ -6,7 +6,13 @@ import {
   ensureString,
   vars,
 } from "./deps.ts";
-import { DduEvent, DduExtType, DduItem, DduOptions } from "./types.ts";
+import {
+  DduEvent,
+  DduExtType,
+  DduItem,
+  DduOptions,
+  Previewer,
+} from "./types.ts";
 import { Ddu } from "./ddu.ts";
 import { ContextBuilder, defaultDduOptions } from "./context.ts";
 
@@ -215,6 +221,17 @@ export async function main(denops: Denops) {
 
       const ddu = getDdu(name);
       await ddu.expandItem(denops, item);
+    },
+    async getPreviewer(
+      arg1: unknown,
+      arg2: unknown,
+      arg3: unknown,
+    ): Promise<Previewer> {
+      const name = ensureString(arg1);
+      const items = ensureObject(arg2) as DduItem;
+      const actionParams = ensureObject(arg3);
+      const ddu = getDdu(name);
+      return await ddu.getPreviewer(denops, items, actionParams);
     },
   };
 

--- a/denops/ddu/base/kind.ts
+++ b/denops/ddu/base/kind.ts
@@ -1,4 +1,11 @@
-import { ActionOptions, Actions, KindOptions } from "../types.ts";
+import {
+  ActionOptions,
+  Actions,
+  DduItem,
+  KindOptions,
+  Previewer,
+} from "../types.ts";
+import { Denops } from "../deps.ts";
 
 export abstract class BaseKind<
   Params extends Record<string, unknown>,
@@ -11,6 +18,14 @@ export abstract class BaseKind<
   actions: Actions<Params> = {};
 
   abstract params(): Params;
+
+  getPreviewer(
+    _denops: Denops,
+    _item: DduItem,
+    _param: unknown,
+  ): Previewer {
+    return undefined;
+  }
 }
 
 export function defaultKindOptions(): KindOptions {

--- a/denops/ddu/base/kind.ts
+++ b/denops/ddu/base/kind.ts
@@ -23,8 +23,8 @@ export abstract class BaseKind<
     _denops: Denops,
     _item: DduItem,
     _param: unknown,
-  ): Previewer | undefined {
-    return undefined;
+  ): Promise<Previewer | undefined> {
+    return Promise.resolve(undefined);
   }
 }
 

--- a/denops/ddu/base/kind.ts
+++ b/denops/ddu/base/kind.ts
@@ -23,7 +23,7 @@ export abstract class BaseKind<
     _denops: Denops,
     _item: DduItem,
     _param: unknown,
-  ): Previewer {
+  ): Previewer | undefined {
     return undefined;
   }
 }

--- a/denops/ddu/base/kind.ts
+++ b/denops/ddu/base/kind.ts
@@ -3,9 +3,17 @@ import {
   Actions,
   DduItem,
   KindOptions,
+  PreviewContext,
   Previewer,
 } from "../types.ts";
 import { Denops } from "../deps.ts";
+
+export type GetPreviewerArguments = {
+  denops: Denops;
+  previewContext: PreviewContext;
+  item: DduItem;
+  actionParams: unknown;
+};
 
 export abstract class BaseKind<
   Params extends Record<string, unknown>,
@@ -19,11 +27,7 @@ export abstract class BaseKind<
 
   abstract params(): Params;
 
-  getPreviewer(
-    _denops: Denops,
-    _item: DduItem,
-    _param: unknown,
-  ): Promise<Previewer | undefined> {
+  getPreviewer({}: GetPreviewerArguments): Promise<Previewer | undefined> {
     return Promise.resolve(undefined);
   }
 }

--- a/denops/ddu/ddu.ts
+++ b/denops/ddu/ddu.ts
@@ -15,6 +15,7 @@ import {
   FilterOptions,
   Item,
   KindOptions,
+  PreviewContext,
   Previewer,
   SourceOptions,
   UiOptions,
@@ -863,6 +864,7 @@ export class Ddu {
     denops: Denops,
     item: DduItem,
     actionParams: unknown,
+    previewContext: PreviewContext,
   ): Promise<Previewer | undefined> {
     const source = this.sources[item.__sourceName];
     const kindName = source.kind;
@@ -874,7 +876,7 @@ export class Ddu {
       return;
     }
 
-    return kind.getPreviewer(denops, item, actionParams);
+    return kind.getPreviewer({ denops, item, actionParams, previewContext });
   }
 }
 

--- a/denops/ddu/ddu.ts
+++ b/denops/ddu/ddu.ts
@@ -15,6 +15,7 @@ import {
   FilterOptions,
   Item,
   KindOptions,
+  Previewer,
   SourceOptions,
   UiOptions,
   UserSource,
@@ -856,6 +857,24 @@ export class Ddu {
     items = await callFilters(sourceOptions.converters, input, items);
 
     return [this.gatherStates[index].done, allItems, items];
+  }
+
+  async getPreviewer(
+    denops: Denops,
+    item: DduItem,
+    actionParams: unknown,
+  ): Promise<Previewer> {
+    const source = this.sources[item.__sourceName];
+    const kindName = source.kind;
+
+    await this.autoload(denops, "kind", [kindName]);
+
+    const kind = this.kinds[kindName];
+    if (!kind) {
+      return;
+    }
+
+    return kind.getPreviewer(denops, item, actionParams);
   }
 }
 

--- a/denops/ddu/ddu.ts
+++ b/denops/ddu/ddu.ts
@@ -863,7 +863,7 @@ export class Ddu {
     denops: Denops,
     item: DduItem,
     actionParams: unknown,
-  ): Promise<Previewer> {
+  ): Promise<Previewer | undefined> {
     const source = this.sources[item.__sourceName];
     const kindName = source.kind;
 

--- a/denops/ddu/ddu.ts
+++ b/denops/ddu/ddu.ts
@@ -870,7 +870,7 @@ export class Ddu {
     await this.autoload(denops, "kind", [kindName]);
 
     const kind = this.kinds[kindName];
-    if (!kind) {
+    if (!kind || !kind.getPreviewer) {
       return;
     }
 

--- a/denops/ddu/types.ts
+++ b/denops/ddu/types.ts
@@ -139,7 +139,7 @@ export type PreviewContext = {
   width: number;
   isFloating: boolean;
   isVertical: boolean;
-}
+};
 
 export type PreviewHighlight = ItemHighlight & {
   row: number;

--- a/denops/ddu/types.ts
+++ b/denops/ddu/types.ts
@@ -134,6 +134,9 @@ export enum ActionFlags {
   Persist = 1 << 2,
 }
 
+export type PreviewHighlight = ItemHighlight & {
+  row: number;
+};
 export type TermPreviewer = {
   kind: "terminal";
   cmds: string[];
@@ -142,7 +145,6 @@ export type TermPreviewer = {
 export type NoFilePreviewer = {
   kind: "nofile";
   contents: string[];
-  syntax?: string;
 } & PreviewerCommon;
 
 export type BufferPreviewer = {
@@ -152,8 +154,9 @@ export type BufferPreviewer = {
 } & PreviewerCommon;
 
 type PreviewerCommon = {
-  highlights?: ItemHighlight[];
+  highlights?: PreviewHighlight[];
   lineNr?: number;
+  syntax?: string;
 };
 
 export type Previewer =

--- a/denops/ddu/types.ts
+++ b/denops/ddu/types.ts
@@ -156,11 +156,11 @@ export type BufferPreviewer = {
 type PreviewerCommon = {
   highlights?: PreviewHighlight[];
   lineNr?: number;
+  pattern?: string;
   syntax?: string;
 };
 
 export type Previewer =
   | TermPreviewer
   | BufferPreviewer
-  | NoFilePreviewer
-  | undefined;
+  | NoFilePreviewer;

--- a/denops/ddu/types.ts
+++ b/denops/ddu/types.ts
@@ -133,3 +133,31 @@ export enum ActionFlags {
   Redraw = 1 << 1,
   Persist = 1 << 2,
 }
+
+export type TermPreviewer = {
+  kind: "terminal";
+  cmds: string[];
+};
+
+export type NoFilePreviewer = {
+  kind: "nofile";
+  contents: string[];
+  syntax?: string;
+} & PreviewerCommon;
+
+export type BufferPreviewer = {
+  kind: "buffer";
+  expr?: number | string;
+  path?: string;
+} & PreviewerCommon;
+
+type PreviewerCommon = {
+  highlights?: ItemHighlight[];
+  lineNr?: number;
+};
+
+export type Previewer =
+  | TermPreviewer
+  | BufferPreviewer
+  | NoFilePreviewer
+  | undefined;

--- a/denops/ddu/types.ts
+++ b/denops/ddu/types.ts
@@ -134,6 +134,13 @@ export enum ActionFlags {
   Persist = 1 << 2,
 }
 
+export type PreviewContext = {
+  height: number;
+  width: number;
+  isFloating: boolean;
+  isVertical: boolean;
+}
+
 export type PreviewHighlight = ItemHighlight & {
   row: number;
 };

--- a/denops/ddu/types.ts
+++ b/denops/ddu/types.ts
@@ -134,6 +134,9 @@ export enum ActionFlags {
   Persist = 1 << 2,
 }
 
+/**
+ * Information of preview window
+ */
 export type PreviewContext = {
   height: number;
   width: number;
@@ -145,29 +148,66 @@ export type PreviewHighlight = ItemHighlight & {
   row: number;
 };
 
+/**
+ * Preview type which uses Vim/Neovim's terminal feature
+ */
 export type TermPreviewer = {
   kind: "terminal";
+  /**
+   * Commands passed to `termopen()` or `term_start()` to render the preview
+   */
   cmds: string[];
 };
 
+/**
+ * Preview type which shows the contents specified by the `contents` property
+ */
 export type NoFilePreviewer = {
   kind: "nofile";
+  /**
+   * Contents to be shown in the preview buffer
+   */
   contents: string[];
 } & PreviewerCommon;
 
+/**
+ * Preview type which shows the contents of files or existing buffers
+ */
 export type BufferPreviewer = {
   kind: "buffer";
+  /**
+   * Buffer expression, which is the same as the arguments of `bufname()`
+   */
   expr?: number | string;
+  /**
+   * Path of file to preview
+   */
   path?: string;
 } & PreviewerCommon;
 
 type PreviewerCommon = {
+  /**
+   * Highlights to apply in the preview buffer
+   */
   highlights?: PreviewHighlight[];
+  /**
+   * Line number of preview buffer to be made center and highlighted
+   */
   lineNr?: number;
+  /**
+   * Pattern to jump to and highlight
+   */
   pattern?: string;
+  /**
+   * Syntax to apply in the preview buffer
+   */
   syntax?: string;
 };
 
+/**
+ *  Previewer defines how the preview is rendered
+ *  This must be implemented in the ddu-ui
+ */
 export type Previewer =
   | TermPreviewer
   | BufferPreviewer

--- a/denops/ddu/types.ts
+++ b/denops/ddu/types.ts
@@ -137,6 +137,7 @@ export enum ActionFlags {
 export type PreviewHighlight = ItemHighlight & {
   row: number;
 };
+
 export type TermPreviewer = {
   kind: "terminal";
   cmds: string[];

--- a/doc/ddu.txt
+++ b/doc/ddu.txt
@@ -207,6 +207,18 @@ ddu#get_item_actions({name}, {items})
 		Get the {name} actions for {items}.
 		Note: You cannot mix multiple kinds/sources.
 
+							*ddu#get_previewer()*
+ddu#get_previewer({name}, {item}, {params}, {context})
+		Get previewer for {item}.
+
+		{name} is specified ddu name(|ddu-option-name|).
+
+		{params} is action params.
+
+		{context} is preview context.
+
+		Note: It is for creating UI interface.
+
 							*ddu#item_action()*
 ddu#item_action({name}, {action}, {items}, {params})
 		Do the {action} action for {items}.
@@ -709,6 +721,11 @@ actions			(Record<string, function>)	(Required)
 						*ddu-kind-attribute-params*
 params			(function)			(Required)
 		Called to get kind params.
+
+					*ddu-kind-attribute-getPreviewer*
+getPreviewer		(function)			(Optional)
+		Called to get previewer. Previewer defines how preview is
+		rendered in the preview window.
 
 
 ==============================================================================


### PR DESCRIPTION
I added `getPreviewer()` function, which returns `Previewer`.
`Previewer` is an interface which defines how the preview is rendered.
```mermaid
sequenceDiagram
    ddu-ui->>ddu: ddu#35;get_previewer()
    ddu->>ddu-kind: getPreviewer()
    ddu-kind->>ddu: Previewer
    ddu->>ddu-ui: Previewer
    ddu-ui->>ddu-ui: render preview buffer
```