### PR TITLE
Using `getcmdwintype()` to detect command line window

### DIFF
--- a/autoload/ddu.vim
+++ b/autoload/ddu.vim
@@ -38,7 +38,7 @@ function! ddu#_request(method, args) abort
     return {}
   endif
 
-  if bufname('%') ==# '[Command Line]'
+  if getcmdwintype() !=# ''
     " Must quit from command line window
     quit
   endif


### PR DESCRIPTION
If buffer name is i18n-ed, command-line-window detection will fail.