### PR TITLE
Apply filters except for matchers to expanded items

### DIFF
--- a/doc/ddu.txt
+++ b/doc/ddu.txt
@@ -529,6 +529,7 @@ matchers		(string[])
 		It is a list of registered filter names to filter items
 		by user input.
 		Items will be processed in the order you specify here.
+		Note: They are not applyed to expanded items.
 
 		Default: []
 


### PR DESCRIPTION
## Problem
Children items are not sorted/converted even though sorters and converters are specified.

## Solution
Apply filters to children. But I don't know if matchers should be applied to children, so I excluded them.