### PR TITLE
fix prefix matcher for search and treePath

### DIFF
--- a/denops/ddu/ddu.ts
+++ b/denops/ddu/ddu.ts
@@ -950,7 +950,7 @@ export class Ddu {
         // Note: Skip hidden directory
         if (
           child.isTree && child.treePath &&
-          (!search || child.treePath.startsWith(search)) &&
+          (!search || search.startsWith(child.treePath)) &&
           !basename(child.treePath).startsWith(".")
         ) {
           // Expand is not completed yet.


### PR DESCRIPTION
This comparison is probably the other way around, as we want to test that the `child` is the parent of the `search`.