### PR TITLE
refactor gatherItems with async generator

### DIFF
--- a/denops/ddu/ddu.ts
+++ b/denops/ddu/ddu.ts
@@ -294,7 +294,7 @@ export class Ddu {
             )
           ) {
             if (this.finished) {
-              break;;
+              break;
             }
             if (!newItems.length) {
               continue;

--- a/denops/ddu/ddu.ts
+++ b/denops/ddu/ddu.ts
@@ -296,7 +296,7 @@ export class Ddu {
             if (this.finished) {
               break;
             }
-            if (!newItems.length) {
+            if (!newItems.length > 0) {
               continue;
             }
             this.gatherStates[index].items = this.gatherStates[index].items

--- a/denops/ddu/ddu.ts
+++ b/denops/ddu/ddu.ts
@@ -387,7 +387,6 @@ export class Ddu {
 
     for await (const chunk of sourceItems) {
       if (this.finished) {
-        // Note: Must return after cancel()
         return;
       }
       const newItems = chunk.map((item: Item) =>

--- a/denops/ddu/ddu.ts
+++ b/denops/ddu/ddu.ts
@@ -296,7 +296,7 @@ export class Ddu {
             if (this.finished) {
               break;
             }
-            if (!newItems.length > 0) {
+            if (newItems.length === 0) {
               continue;
             }
             this.gatherStates[index].items = this.gatherStates[index].items


### PR DESCRIPTION
基本的な挙動は変えずにリファクタしてみました。

これによりgatherItemsが後続処理を持たなくなるので、refresh時とexpandItem時でgatherItemsを使いまわせ、item収集後の処理は呼び出し元の責務になりました。