### PR TITLE
refactor: define parameter types

### DIFF
--- a/denops/ddu/app.ts
+++ b/denops/ddu/app.ts
@@ -7,6 +7,7 @@ import {
   vars,
 } from "./deps.ts";
 import {
+  BaseFilterParams,
   Clipboard,
   DduEvent,
   DduExtType,
@@ -283,7 +284,7 @@ export async function main(denops: Denops) {
       [
         string,
         FilterOptions,
-        Record<string, unknown>,
+        BaseFilterParams,
       ]
     > {
       const name = ensureString(arg1);

--- a/denops/ddu/base/column.ts
+++ b/denops/ddu/base/column.ts
@@ -1,13 +1,15 @@
 import { ColumnOptions, DduItem, DduOptions, ItemHighlight } from "../types.ts";
 import { Denops } from "../deps.ts";
 
-export type OnInitArguments<Params extends Record<string, unknown>> = {
+export type BaseColumnParams = Record<string, unknown>;
+
+export type OnInitArguments<Params extends BaseColumnParams> = {
   denops: Denops;
   columnOptions: ColumnOptions;
   columnParams: Params;
 };
 
-export type GetLengthArguments<Params extends Record<string, unknown>> = {
+export type GetLengthArguments<Params extends BaseColumnParams> = {
   denops: Denops;
   options: DduOptions;
   columnOptions: ColumnOptions;
@@ -15,7 +17,7 @@ export type GetLengthArguments<Params extends Record<string, unknown>> = {
   items: DduItem[];
 };
 
-export type GetTextArguments<Params extends Record<string, unknown>> = {
+export type GetTextArguments<Params extends BaseColumnParams> = {
   denops: Denops;
   options: DduOptions;
   columnOptions: ColumnOptions;
@@ -30,7 +32,7 @@ export type GetTextResult = {
   highlights?: ItemHighlight[];
 };
 
-export abstract class BaseColumn<Params extends Record<string, unknown>> {
+export abstract class BaseColumn<Params extends BaseColumnParams> {
   name = "";
   path = "";
   isInitialized = false;

--- a/denops/ddu/base/filter.ts
+++ b/denops/ddu/base/filter.ts
@@ -1,19 +1,21 @@
 import { DduItem, DduOptions, FilterOptions, SourceOptions } from "../types.ts";
 import { Denops } from "../deps.ts";
 
-export type OnInitArguments<Params extends Record<string, unknown>> = {
+export type BaseFilterParams = Record<string, unknown>;
+
+export type OnInitArguments<Params extends BaseFilterParams> = {
   denops: Denops;
   filterOptions: FilterOptions;
   filterParams: Params;
 };
 
-export type OnRefreshItemsArguments<Params extends Record<string, unknown>> = {
+export type OnRefreshItemsArguments<Params extends BaseFilterParams> = {
   denops: Denops;
   filterOptions: FilterOptions;
   filterParams: Params;
 };
 
-export type FilterArguments<Params extends Record<string, unknown>> = {
+export type FilterArguments<Params extends BaseFilterParams> = {
   denops: Denops;
   options: DduOptions;
   sourceOptions: SourceOptions;
@@ -23,7 +25,7 @@ export type FilterArguments<Params extends Record<string, unknown>> = {
   items: DduItem[];
 };
 
-export abstract class BaseFilter<Params extends Record<string, unknown>> {
+export abstract class BaseFilter<Params extends BaseFilterParams> {
   name = "";
   path = "";
   isInitialized = false;

--- a/denops/ddu/base/kind.ts
+++ b/denops/ddu/base/kind.ts
@@ -8,6 +8,8 @@ import {
 } from "../types.ts";
 import { Denops } from "../deps.ts";
 
+export type BaseKindParams = Record<string, unknown>;
+
 export type GetPreviewerArguments = {
   denops: Denops;
   previewContext: PreviewContext;
@@ -16,7 +18,7 @@ export type GetPreviewerArguments = {
 };
 
 export abstract class BaseKind<
-  Params extends Record<string, unknown>,
+  Params extends BaseKindParams,
 > {
   name = "";
   path = "";

--- a/denops/ddu/base/source.ts
+++ b/denops/ddu/base/source.ts
@@ -8,20 +8,22 @@ import {
 } from "../types.ts";
 import { Denops } from "../deps.ts";
 
-export type OnInitArguments<Params extends Record<string, unknown>> = {
+export type BaseSourceParams = Record<string, unknown>;
+
+export type OnInitArguments<Params extends BaseSourceParams> = {
   denops: Denops;
   sourceOptions: SourceOptions;
   sourceParams: Params;
 };
 
-export type OnEventArguments<Params extends Record<string, unknown>> = {
+export type OnEventArguments<Params extends BaseSourceParams> = {
   denops: Denops;
   sourceOptions: SourceOptions;
   sourceParams: Params;
   event: DduEvent;
 };
 
-export type GatherArguments<Params extends Record<string, unknown>> = {
+export type GatherArguments<Params extends BaseSourceParams> = {
   denops: Denops;
   context: Context;
   options: DduOptions;
@@ -30,7 +32,7 @@ export type GatherArguments<Params extends Record<string, unknown>> = {
   input: string;
 };
 
-export type CheckUpdatedArguments<Params extends Record<string, unknown>> = {
+export type CheckUpdatedArguments<Params extends BaseSourceParams> = {
   denops: Denops;
   context: Context;
   options: DduOptions;
@@ -39,7 +41,7 @@ export type CheckUpdatedArguments<Params extends Record<string, unknown>> = {
 };
 
 export abstract class BaseSource<
-  Params extends Record<string, unknown>,
+  Params extends BaseSourceParams,
   UserData extends unknown = unknown,
 > {
   name = "";

--- a/denops/ddu/base/ui.ts
+++ b/denops/ddu/base/ui.ts
@@ -8,18 +8,20 @@ import {
 } from "../types.ts";
 import { Denops } from "../deps.ts";
 
-export type UiActions<Params extends Record<string, unknown>> = Record<
+export type BaseUiParams = Record<string, unknown>;
+
+export type UiActions<Params extends BaseUiParams> = Record<
   string,
   (args: ActionArguments<Params>) => Promise<ActionFlags>
 >;
 
-export type OnInitArguments<Params extends Record<string, unknown>> = {
+export type OnInitArguments<Params extends BaseUiParams> = {
   denops: Denops;
   uiOptions: UiOptions;
   uiParams: Params;
 };
 
-export type RefreshItemsArguments<Params extends Record<string, unknown>> = {
+export type RefreshItemsArguments<Params extends BaseUiParams> = {
   denops: Denops;
   context: Context;
   options: DduOptions;
@@ -29,7 +31,7 @@ export type RefreshItemsArguments<Params extends Record<string, unknown>> = {
   items: DduItem[];
 };
 
-export type CollapseItemArguments<Params extends Record<string, unknown>> = {
+export type CollapseItemArguments<Params extends BaseUiParams> = {
   denops: Denops;
   context: Context;
   options: DduOptions;
@@ -38,7 +40,7 @@ export type CollapseItemArguments<Params extends Record<string, unknown>> = {
   item: DduItem;
 };
 
-export type ExpandItemArguments<Params extends Record<string, unknown>> = {
+export type ExpandItemArguments<Params extends BaseUiParams> = {
   denops: Denops;
   context: Context;
   options: DduOptions;
@@ -48,7 +50,7 @@ export type ExpandItemArguments<Params extends Record<string, unknown>> = {
   children: DduItem[];
 };
 
-export type SearchItemArguments<Params extends Record<string, unknown>> = {
+export type SearchItemArguments<Params extends BaseUiParams> = {
   denops: Denops;
   context: Context;
   options: DduOptions;
@@ -57,7 +59,7 @@ export type SearchItemArguments<Params extends Record<string, unknown>> = {
   item: DduItem;
 };
 
-export type RedrawArguments<Params extends Record<string, unknown>> = {
+export type RedrawArguments<Params extends BaseUiParams> = {
   denops: Denops;
   context: Context;
   options: DduOptions;
@@ -65,7 +67,7 @@ export type RedrawArguments<Params extends Record<string, unknown>> = {
   uiParams: Params;
 };
 
-export type QuitArguments<Params extends Record<string, unknown>> = {
+export type QuitArguments<Params extends BaseUiParams> = {
   denops: Denops;
   context: Context;
   options: DduOptions;
@@ -73,7 +75,7 @@ export type QuitArguments<Params extends Record<string, unknown>> = {
   uiParams: Params;
 };
 
-export type ActionArguments<Params extends Record<string, unknown>> = {
+export type ActionArguments<Params extends BaseUiParams> = {
   denops: Denops;
   context: Context;
   options: DduOptions;
@@ -83,7 +85,7 @@ export type ActionArguments<Params extends Record<string, unknown>> = {
 };
 
 export abstract class BaseUi<
-  Params extends Record<string, unknown>,
+  Params extends BaseUiParams,
 > {
   name = "";
   path = "";

--- a/denops/ddu/context.ts
+++ b/denops/ddu/context.ts
@@ -1,6 +1,11 @@
 import { assertEquals, Denops, fn } from "./deps.ts";
 import {
   ActionOptions,
+  BaseColumnParams,
+  BaseFilterParams,
+  BaseKindParams,
+  BaseSourceParams,
+  BaseUiParams,
   ColumnOptions,
   Context,
   DduOptions,
@@ -33,11 +38,11 @@ export const mergeColumnOptions: Merge<ColumnOptions> = overwrite;
 export const mergeKindOptions: Merge<KindOptions> = overwrite;
 export const mergeActionOptions: Merge<ActionOptions> = overwrite;
 
-export const mergeUiParams: Merge<Record<string, unknown>> = overwrite;
-export const mergeSourceParams: Merge<Record<string, unknown>> = overwrite;
-export const mergeFilterParams: Merge<Record<string, unknown>> = overwrite;
-export const mergeColumnParams: Merge<Record<string, unknown>> = overwrite;
-export const mergeKindParams: Merge<Record<string, unknown>> = overwrite;
+export const mergeUiParams: Merge<BaseUiParams> = overwrite;
+export const mergeSourceParams: Merge<BaseSourceParams> = overwrite;
+export const mergeFilterParams: Merge<BaseFilterParams> = overwrite;
+export const mergeColumnParams: Merge<BaseColumnParams> = overwrite;
+export const mergeKindParams: Merge<BaseKindParams> = overwrite;
 
 export function foldMerge<T>(
   merge: Merge<T>,

--- a/denops/ddu/ddu.ts
+++ b/denops/ddu/ddu.ts
@@ -17,10 +17,15 @@ import {
   ActionOptions,
   ActionResult,
   BaseColumn,
+  BaseColumnParams,
   BaseFilter,
+  BaseFilterParams,
   BaseKind,
+  BaseKindParams,
   BaseSource,
+  BaseSourceParams,
   BaseUi,
+  BaseUiParams,
   Clipboard,
   ColumnOptions,
   Context,
@@ -70,17 +75,17 @@ type GatherState = {
 };
 
 type ItemActions = {
-  source: BaseSource<Record<string, unknown>, unknown>;
-  kind: BaseKind<Record<string, unknown>>;
+  source: BaseSource<BaseSourceParams, unknown>;
+  kind: BaseKind<BaseKindParams>;
   actions: Record<string, unknown>;
 };
 
 export class Ddu {
-  private uis: Record<string, BaseUi<Record<string, unknown>>> = {};
-  private sources: Record<string, BaseSource<Record<string, unknown>>> = {};
-  private filters: Record<string, BaseFilter<Record<string, unknown>>> = {};
-  private kinds: Record<string, BaseKind<Record<string, unknown>>> = {};
-  private columns: Record<string, BaseColumn<Record<string, unknown>>> = {};
+  private uis: Record<string, BaseUi<BaseUiParams>> = {};
+  private sources: Record<string, BaseSource<BaseSourceParams>> = {};
+  private filters: Record<string, BaseFilter<BaseFilterParams>> = {};
+  private kinds: Record<string, BaseKind<BaseKindParams>> = {};
+  private columns: Record<string, BaseColumn<BaseColumnParams>> = {};
   private aliases: Record<DduExtType, Record<string, string>> = {
     ui: {},
     source: {},
@@ -331,7 +336,7 @@ export class Ddu {
   }
 
   async initSource<
-    Params extends Record<string, unknown>,
+    Params extends BaseSourceParams,
     UserData extends unknown,
   >(
     denops: Denops,
@@ -353,7 +358,7 @@ export class Ddu {
   }
 
   private newDduItem<
-    Params extends Record<string, unknown>,
+    Params extends BaseSourceParams,
     UserData extends unknown,
   >(
     sourceIndex: number,
@@ -382,7 +387,7 @@ export class Ddu {
   }
 
   async *gatherItems<
-    Params extends Record<string, unknown>,
+    Params extends BaseSourceParams,
     UserData extends unknown,
   >(
     denops: Denops,
@@ -569,7 +574,7 @@ export class Ddu {
   }
 
   async uiQuit<
-    Params extends Record<string, unknown>,
+    Params extends BaseUiParams,
   >(
     denops: Denops,
     ui: BaseUi<Params>,
@@ -1290,9 +1295,9 @@ export class Ddu {
     denops: Denops,
   ): Promise<
     [
-      BaseUi<Record<string, unknown>> | undefined,
+      BaseUi<BaseUiParams> | undefined,
       UiOptions,
-      Record<string, unknown>,
+      BaseUiParams,
     ]
   > {
     if (!this.uis[this.options.ui]) {
@@ -1322,9 +1327,9 @@ export class Ddu {
     filterName: string,
   ): Promise<
     [
-      BaseFilter<Record<string, unknown>> | undefined,
+      BaseFilter<BaseFilterParams> | undefined,
       FilterOptions,
-      Record<string, unknown>,
+      BaseFilterParams,
     ]
   > {
     await this.autoload(denops, "filter", [filterName]);
@@ -1535,11 +1540,11 @@ export class Ddu {
 }
 
 function uiArgs<
-  Params extends Record<string, unknown>,
+  Params extends BaseUiParams,
 >(
   options: DduOptions,
   ui: BaseUi<Params>,
-): [UiOptions, Record<string, unknown>] {
+): [UiOptions, BaseUiParams] {
   const o = foldMerge(
     mergeUiOptions,
     defaultUiOptions,
@@ -1557,13 +1562,13 @@ function uiArgs<
 }
 
 function sourceArgs<
-  Params extends Record<string, unknown>,
+  Params extends BaseSourceParams,
   UserData extends unknown,
 >(
   options: DduOptions,
   userSource: UserSource | null,
   source: BaseSource<Params, UserData>,
-): [SourceOptions, Record<string, unknown>] {
+): [SourceOptions, BaseSourceParams] {
   const o = foldMerge(
     mergeSourceOptions,
     defaultSourceOptions,
@@ -1583,11 +1588,11 @@ function sourceArgs<
 }
 
 function filterArgs<
-  Params extends Record<string, unknown>,
+  Params extends BaseFilterParams,
 >(
   options: DduOptions,
   filter: BaseFilter<Params>,
-): [FilterOptions, Record<string, unknown>] {
+): [FilterOptions, BaseFilterParams] {
   const o = foldMerge(
     mergeFilterOptions,
     defaultFilterOptions,
@@ -1605,11 +1610,11 @@ function filterArgs<
 }
 
 function columnArgs<
-  Params extends Record<string, unknown>,
+  Params extends BaseColumnParams,
 >(
   options: DduOptions,
   column: BaseColumn<Params>,
-): [ColumnOptions, Record<string, unknown>] {
+): [ColumnOptions, BaseColumnParams] {
   const o = foldMerge(
     mergeColumnOptions,
     defaultColumnOptions,
@@ -1627,11 +1632,11 @@ function columnArgs<
 }
 
 function kindArgs<
-  Params extends Record<string, unknown>,
+  Params extends BaseKindParams,
 >(
   options: DduOptions,
   kind: BaseKind<Params>,
-): [KindOptions, Record<string, unknown>] {
+): [KindOptions, BaseKindParams] {
   const o = foldMerge(
     mergeKindOptions,
     defaultKindOptions,
@@ -1648,10 +1653,12 @@ function kindArgs<
   return [o, p];
 }
 
+type _DummyActionParams = Record<string, unknown>;
+
 function actionArgs(
   options: DduOptions,
   actionName: string,
-): [ActionOptions, Record<string, unknown>] {
+): [ActionOptions, _DummyActionParams] {
   const o = foldMerge(
     mergeActionOptions,
     defaultActionOptions,
@@ -1664,10 +1671,10 @@ function actionArgs(
 }
 
 async function checkUiOnInit(
-  ui: BaseUi<Record<string, unknown>>,
+  ui: BaseUi<BaseUiParams>,
   denops: Denops,
   uiOptions: UiOptions,
-  uiParams: Record<string, unknown>,
+  uiParams: BaseUiParams,
 ) {
   if (ui.isInitialized) {
     return;
@@ -1691,7 +1698,7 @@ async function checkUiOnInit(
 }
 
 async function uiRedraw<
-  Params extends Record<string, unknown>,
+  Params extends BaseUiParams,
 >(
   denops: Denops,
   lock: Lock,
@@ -1728,10 +1735,10 @@ async function uiRedraw<
 }
 
 async function checkFilterOnInit(
-  filter: BaseFilter<Record<string, unknown>>,
+  filter: BaseFilter<BaseFilterParams>,
   denops: Denops,
   filterOptions: FilterOptions,
-  filterParams: Record<string, unknown>,
+  filterParams: BaseFilterParams,
 ) {
   if (filter.isInitialized) {
     return;
@@ -1755,10 +1762,10 @@ async function checkFilterOnInit(
 }
 
 async function checkColumnOnInit(
-  column: BaseColumn<Record<string, unknown>>,
+  column: BaseColumn<BaseColumnParams>,
   denops: Denops,
   columnOptions: FilterOptions,
-  columnParams: Record<string, unknown>,
+  columnParams: BaseColumnParams,
 ) {
   if (column.isInitialized) {
     return;

--- a/denops/ddu/types.ts
+++ b/denops/ddu/types.ts
@@ -3,7 +3,16 @@ export { BaseSource } from "./base/source.ts";
 export { BaseFilter } from "./base/filter.ts";
 export { BaseKind } from "./base/kind.ts";
 export { BaseColumn } from "./base/column.ts";
-export type { UiActions } from "./base/ui.ts";
+export type { BaseUiParams, UiActions } from "./base/ui.ts";
+export type { BaseSourceParams } from "./base/source.ts";
+export type { BaseFilterParams } from "./base/filter.ts";
+export type { BaseKindParams } from "./base/kind.ts";
+export type { BaseColumnParams } from "./base/column.ts";
+import type { BaseUiParams } from "./base/ui.ts";
+import type { BaseSourceParams } from "./base/source.ts";
+import type { BaseFilterParams } from "./base/filter.ts";
+import type { BaseKindParams } from "./base/kind.ts";
+import type { BaseColumnParams } from "./base/column.ts";
 import { Denops } from "./deps.ts";
 
 export type DduExtType = "ui" | "source" | "filter" | "kind" | "column";
@@ -29,7 +38,7 @@ export type Custom = {
 export type UserSource = {
   name: string;
   options?: SourceOptions;
-  params?: Record<string, unknown>;
+  params?: BaseSourceParams;
 };
 
 export type SourceInfo = {
@@ -42,12 +51,12 @@ export type SourceInfo = {
 export type DduOptions = {
   actionOptions: Record<string, Partial<ActionOptions>>;
   columnOptions: Record<string, Partial<ColumnOptions>>;
-  columnParams: Record<string, Partial<Record<string, unknown>>>;
+  columnParams: Record<string, Partial<BaseColumnParams>>;
   filterOptions: Record<string, Partial<FilterOptions>>;
-  filterParams: Record<string, Partial<Record<string, unknown>>>;
+  filterParams: Record<string, Partial<BaseFilterParams>>;
   input: string;
   kindOptions: Record<string, Partial<KindOptions>>;
-  kindParams: Record<string, Partial<Record<string, unknown>>>;
+  kindParams: Record<string, Partial<BaseKindParams>>;
   name: string;
   profile: boolean;
   push: boolean;
@@ -55,12 +64,12 @@ export type DduOptions = {
   resume: boolean;
   searchPath: string;
   sourceOptions: Record<SourceName, Partial<SourceOptions>>;
-  sourceParams: Record<SourceName, Partial<Record<string, unknown>>>;
+  sourceParams: Record<SourceName, Partial<BaseSourceParams>>;
   sources: UserSource[];
   sync: boolean;
   ui: string;
   uiOptions: Record<string, Partial<UiOptions>>;
-  uiParams: Record<string, Partial<Record<string, unknown>>>;
+  uiParams: Record<string, Partial<BaseUiParams>>;
   volatile: boolean;
 };
 


### PR DESCRIPTION
There are a lot of `Record<string, unknown>` in the source.
They are defined for different uses, which is confusing.
Define aliases makes it easier to understand type information.

This PR only defines type aliases and replaces it.
No changes in behavior.