### PR TITLE
Respect item.level

### DIFF
--- a/denops/ddu/ddu.ts
+++ b/denops/ddu/ddu.ts
@@ -421,7 +421,7 @@ export class Ddu {
       matcherKey,
       __sourceIndex: sourceIndex,
       __sourceName: source.name,
-      __level: (level ?? 0) + (item.level ?? 0),
+      __level: item.level ?? level ?? 0,
       __expanded: Boolean(
         item.treePath &&
           this.isExpanded(convertTreePath(item.treePath)),


### PR DESCRIPTION
When item.level is set, use it as is. No addition is necessary.