### PR TITLE
Describe two representation ways of the TreePath

### DIFF
--- a/denops/ddu/types.ts
+++ b/denops/ddu/types.ts
@@ -35,6 +35,10 @@ export type KindName = string;
 export type ColumnName = string;
 export type ActionName = string;
 
+// TreePath is the path (string) or list of the path segments(string[])
+// You can represents two ways for one path like below.
+//    "/aa/bb/cc"
+//    ["/", "aa", "bb", "cc"]
 export type TreePath = string | string[];
 
 export type Context = {

--- a/doc/ddu.txt
+++ b/doc/ddu.txt
@@ -179,6 +179,9 @@ resume			(boolean)
 searchPath		(string | string[])
 		Search the path.  This only works when specified |ddu#start()|
 		or |ddu#redraw()|.
+		NOTE: You can represents a path by two way like below.
+			"/aa/bb/cc" (string)
+			["/", "aa", "bb", "cc"] (string[])
 		NOTE: The path must be absolute path.
 
 		Default: ""
@@ -722,6 +725,9 @@ maxItems		(number)
 						*ddu-source-option-path*
 path			(string | string[])
 		Specify an initial narrowing path.
+		NOTE: You can represents a path by two way like below.
+			"/aa/bb/cc" (string)
+			["/", "aa", "bb", "cc"] (string[])
 		NOTE: It must be full path.
 
 						*ddu-source-option-sorters*
@@ -1091,6 +1097,9 @@ status			(object)			(Optional)
 					*ddu-item-attribute-treePath*
 treePath		(string | string[])		(Optional)
 		The item tree path.
+		NOTE: You can represents a path by two way like below.
+			"/aa/bb/cc" (string)
+			["/", "aa", "bb", "cc"] (string[])
 		NOTE: The attribute must be set to support tree feature.
 
 					*ddu-item-attribute-word*


### PR DESCRIPTION
I was not clear on the difference between string and string[] in TreePath.
I misunderstood that multiple paths could be specified because sourceOptions.path can be either a string or a string[].
I have noted what it means to use string[] for a parameter or type definition using TreePath, respectively.
