### PR TITLE
RFC: 走ってるソースあってもvolatile効くようにしてみた

### DIFF
--- a/denops/ddu/app.ts
+++ b/denops/ddu/app.ts
@@ -238,6 +238,24 @@ export function main(denops: Denops) {
     async redraw(arg1: unknown, arg2: unknown): Promise<void> {
       queuedName = ensure(arg1, is.String);
       queuedRedrawOption = ensure(arg2, is.Record) as RedrawOption;
+      const ddu = getDdu(queuedName);
+      // Check volatile sources
+      const volatiles = [];
+      let index = 0;
+      for (const sourceArgs of ddu.getSourceArgs()) {
+        if (sourceArgs[0].volatile) {
+          volatiles.push(index);
+        }
+        index++;
+      }
+      if (
+        queuedRedrawOption?.refreshItems ||
+        queuedRedrawOption?.updateOptions ||
+        volatiles.length > 0
+      ) {
+        ddu.cancelToRefresh();
+        ddu.resetCancelledToRefresh();
+      }
 
       // NOTE: must be locked
       await lock.lock(async () => {

--- a/denops/ddu/ddu.ts
+++ b/denops/ddu/ddu.ts
@@ -787,12 +787,12 @@ export class Ddu {
     this.resetAbortController();
   }
 
-  private cancelToRefresh() {
+  cancelToRefresh() {
     this.cancelledToRefresh = true;
     this.abortController.abort("cancelToRefresh");
   }
 
-  private resetCancelledToRefresh() {
+  resetCancelledToRefresh() {
     this.cancelledToRefresh = false;
     this.resetAbortController();
   }


### PR DESCRIPTION
#81 を大雑把に修正したものです。
gatherが完了していないソースがあるとロックがかかっていてredrawが止まってしまうので、一旦refreshのチェック部分を外に出してみました
ただ、他の問題(例えば、この状態だとactionがブロックされるのでfilter閉じようとすると固まったりする)もあるため根本的な改善が必要だと思われます。