### PR TITLE
fix column when fire expandItem action

### DIFF
--- a/denops/ddu/ddu.ts
+++ b/denops/ddu/ddu.ts
@@ -1280,7 +1280,7 @@ export class Ddu {
       await this.#callColumns(
         denops,
         sourceOptions.columns,
-        children,
+        [parent].concat(children),
       );
     } finally {
       // Restore path


### PR DESCRIPTION
When I use column as filer, parent item's column is not be updated.

So I fix it.

before
![image](https://github.com/Shougo/ddu.vim/assets/50443168/a4df950a-4561-4938-9551-dbf5921073d7)

after
![image](https://github.com/Shougo/ddu.vim/assets/50443168/91334812-0575-45cd-b4f9-685e6423e528)
