### PR TITLE
fix: use item.kind (if available) instead of source.kind to get preview

### DIFF
--- a/denops/ddu/ddu.ts
+++ b/denops/ddu/ddu.ts
@@ -2155,7 +2155,7 @@ export class Ddu {
     if (!source) {
       return;
     }
-    const kindName = source.kind;
+    const kindName = item.kind ?? source.kind;
 
     const kind = await this.getKind(denops, kindName);
     if (!kind || !kind.getPreviewer) {


### PR DESCRIPTION
Before this commit, to get preview we get kind name from source's kind only.

So if I want to custom each items via other sources but still don't want to change the item's kind, I can't do that.

For example, the other sources is [ddu-source-custom_params](https://github.com/kamecha/ddu-source-custom_params)

From this commit, we can get kind name from source's kind or from item's kind. So we can custom each items via other sources.
