### PR TITLE
fix: revert refresh target check in cancel

### DIFF
--- a/denops/ddu/ddu.ts
+++ b/denops/ddu/ddu.ts
@@ -40,6 +40,7 @@ import {
   AvailableSourceInfo,
   GatherState,
   GatherStateAbortable,
+  isRefreshTarget,
 } from "./state.ts";
 import {
   callColumns,
@@ -884,10 +885,7 @@ export class Ddu {
     await Promise.all(
       [...this.#gatherStates]
         .map(([sourceIndex, state]) => {
-          if (
-            (refreshIndexes.length === 0 ||
-              refreshIndexes.includes(sourceIndex)) && state.signal.aborted
-          ) {
+          if (isRefreshTarget(sourceIndex, refreshIndexes)) {
             this.#gatherStates.delete(sourceIndex);
             return state.waitDone;
           }

--- a/denops/ddu/state.ts
+++ b/denops/ddu/state.ts
@@ -149,7 +149,7 @@ export class GatherState<
   }
 }
 
-function isRefreshTarget(
+export function isRefreshTarget(
   sourceIndex: number,
   refreshIndexes: number[],
 ): boolean {


### PR DESCRIPTION
This is fixes bug in #107 (and refactor for 39bc2b7).

There is no need to check `signal.aborted`.

### Problem

1. "quit" then aborts all states.
2. "cancel" by "redraw" then clear all states, because all states aborted when (1).