### PR TITLE
fix: Missing "name" argument of setAlias in ConfigArguments

### DIFF
--- a/denops/ddu/base/config.ts
+++ b/denops/ddu/base/config.ts
@@ -5,7 +5,7 @@ import type { Denops } from "jsr:@denops/std@~7.4.0";
 export type ConfigArguments = {
   denops: Denops;
   contextBuilder: ContextBuilder;
-  setAlias: (type: DduAliasType, alias: string, base: string) => void;
+  setAlias: (name: string, type: DduAliasType, alias: string, base: string) => void;
 };
 
 export abstract class BaseConfig {


### PR DESCRIPTION
Exported type of `setAlias` property in `ConfigArguments` type doesn't have the first `name` argument.  Therefore this is different from the type of `setAlias` defined in `denops/ddu/app.ts`.  This PR fixes this.