### PR TITLE
Fix: Ensure winId is carried over to the pushed context

### DIFF
--- a/denops/ddu/app.ts
+++ b/denops/ddu/app.ts
@@ -324,6 +324,7 @@ export const main: Entrypoint = (denops: Denops) => {
           ]);
 
           [context, options] = await contextBuilder.get(denops, userOptions);
+          context.winId = prevDdu.getContext().winId;
         } else {
           ddu = getDdu(options.name);
         }


### PR DESCRIPTION
## Issue

When calling `ddu.vim`'s `start` function with `push=true`, the `context.winId` is incorrectly set to the `winId` of an already open `ddu.vim` instance. This results in the return window selection being incorrect after closing the `ddu.vim` window.

## Fix

To address this issue, the `winId` is now carried over from the previous `ddu` context when `push=true`. This ensures that the `context.winId` remains consistent with the previously opened `ddu` instance, allowing the return window to be selected correctly.

## Verification

Tests and verifications have been conducted to ensure that the `winId` is correctly carried over and that the return window selection works as expected.

```
:new
:wincmd j
:call ddu#start(...)
:call ddu#ui#do_action("chooseAction")
:q
:q
```