### PR TITLE
fix: gather sources does not cancelled on refresh

### DIFF
--- a/denops/ddu/ddu.ts
+++ b/denops/ddu/ddu.ts
@@ -26,8 +26,12 @@ import type { BaseSource } from "./base/source.ts";
 import type { Loader } from "./loader.ts";
 import { convertUserString, printError, treePath2Filename } from "./utils.ts";
 import type { AvailableSourceInfo, GatherStateAbortable } from "./state.ts";
-import { GatherState } from "./state.ts";
-import { isRefreshTarget } from "./state.ts";
+import {
+  GatherState,
+  isRefreshTarget,
+  QuitAbortReason,
+  RefreshAbortReason,
+} from "./state.ts";
 import {
   callColumns,
   callFilters,
@@ -848,7 +852,8 @@ export class Ddu {
   quit() {
     // NOTE: quitted flag must be called after ui.quit().
     this.#quitted = true;
-    this.#aborter.abort({ reason: "quit" });
+    const reason = new QuitAbortReason();
+    this.#aborter.abort(reason);
     this.#context.done = true;
   }
 
@@ -860,7 +865,8 @@ export class Ddu {
   async cancelToRefresh(
     refreshIndexes: number[] = [],
   ): Promise<void> {
-    this.#aborter.abort({ reason: "cancelToRefresh", refreshIndexes });
+    const reason = new RefreshAbortReason(refreshIndexes);
+    this.#aborter.abort(reason);
 
     await Promise.all(
       [...this.#gatherStates]

--- a/denops/ddu/ext.ts
+++ b/denops/ddu/ext.ts
@@ -47,6 +47,7 @@ import type { BaseKind } from "./base/kind.ts";
 import type { BaseSource } from "./base/source.ts";
 import type { BaseUi } from "./base/ui.ts";
 import type { Loader } from "./loader.ts";
+import type { BaseAbortReason } from "./state.ts";
 import { convertUserString, printError } from "./utils.ts";
 
 import type { Denops } from "jsr:@denops/std@~7.4.0";
@@ -925,7 +926,7 @@ export async function uiRedraw<
     }
 
     try {
-      if (signal.aborted) {
+      if ((signal.reason as BaseAbortReason)?.type === "quit") {
         await ui.quit({
           denops,
           context,
@@ -953,7 +954,7 @@ export async function uiRedraw<
       });
 
       // NOTE: ddu may be quitted after redraw
-      if (signal.aborted) {
+      if ((signal.reason as BaseAbortReason)?.type === "quit") {
         await ui.quit({
           denops,
           context,

--- a/denops/ddu/state.ts
+++ b/denops/ddu/state.ts
@@ -14,14 +14,29 @@ export type AvailableSourceInfo<
   sourceParams: Params;
 };
 
-type GatherStateAbortReason =
-  | {
-    reason: "quit";
+export type BaseAbortReason = {
+  readonly type: string;
+};
+
+export class QuitAbortReason extends Error implements BaseAbortReason {
+  override name = "QuitAbortReason";
+  readonly type = "quit";
+}
+
+export class RefreshAbortReason extends Error implements BaseAbortReason {
+  override name = "RefreshAbortReason";
+  readonly type = "cancelToRefresh";
+  readonly refreshIndexes: readonly number[];
+
+  constructor(refreshIndexes: number[] = []) {
+    super();
+    this.refreshIndexes = refreshIndexes;
   }
-  | {
-    reason: "cancelToRefresh";
-    refreshIndexes: number[];
-  };
+}
+
+export type GatherStateAbortReason =
+  | QuitAbortReason
+  | RefreshAbortReason;
 
 export type GatherStateAbortable = {
   abort(reason: GatherStateAbortReason): void;

--- a/denops/ddu/state.ts
+++ b/denops/ddu/state.ts
@@ -1,9 +1,6 @@
 import type { BaseParams, DduItem, SourceOptions } from "./types.ts";
 import type { BaseSource } from "./base/source.ts";
 
-import { is } from "jsr:@core/unknownutil@~4.3.0/is";
-import { maybe } from "jsr:@core/unknownutil@~4.3.0/maybe";
-
 export type AvailableSourceInfo<
   Params extends BaseParams = BaseParams,
   UserData extends unknown = unknown,
@@ -52,58 +49,13 @@ export class GatherState<
   #isDone = false;
   readonly #waitDone = Promise.withResolvers<void>();
   readonly #aborter = new AbortController();
-  #resetParentSignal?: AbortController;
 
   constructor(
     sourceInfo: AvailableSourceInfo<Params, UserData>,
     itemsStream: ReadableStream<DduItem[]>,
-    options?: {
-      signal?: AbortSignal;
-    },
   ) {
-    const { signal: parentSignal } = options ?? {};
     this.sourceInfo = sourceInfo;
-    this.#chainAbortSignal(parentSignal);
     this.itemsStream = this.#processItemsStream(itemsStream);
-  }
-
-  resetSignal(signal?: AbortSignal): void {
-    // Do nothing if already aborted.
-    if (!this.#aborter.signal.aborted) {
-      this.#chainAbortSignal(signal);
-    }
-  }
-
-  #chainAbortSignal(parentSignal?: AbortSignal): void {
-    this.#resetParentSignal?.abort();
-    if (parentSignal == null) {
-      return;
-    }
-
-    const abortIfTarget = () => {
-      const reason = maybe(
-        parentSignal.reason,
-        is.ObjectOf({ reason: is.String }),
-      ) as GatherStateAbortReason | undefined;
-      if (
-        reason?.reason !== "cancelToRefresh" ||
-        isRefreshTarget(this.sourceInfo.sourceIndex, reason.refreshIndexes)
-      ) {
-        this.#aborter.abort(parentSignal.reason);
-      }
-    };
-
-    if (parentSignal.aborted) {
-      abortIfTarget();
-    } else {
-      this.#resetParentSignal = new AbortController();
-      parentSignal.addEventListener("abort", () => abortIfTarget(), {
-        signal: AbortSignal.any([
-          this.#aborter.signal,
-          this.#resetParentSignal.signal,
-        ]),
-      });
-    }
   }
 
   #processItemsStream(
@@ -150,8 +102,12 @@ export class GatherState<
     return this.#waitDone.promise;
   }
 
-  get signal(): AbortSignal {
+  get cancelled(): AbortSignal {
     return this.#aborter.signal;
+  }
+
+  cancel(reason?: unknown): void {
+    this.#aborter.abort(reason);
   }
 
   async readAll(): Promise<void> {


### PR DESCRIPTION
Enabled cancellation of gather sources by locking only the UI during refresh, not the entire refresh process.

This PR includes 3 cumulative commits.  If necessary, these can be separated into individual PRs.
