### PR TITLE
Add CI checks for publish

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -43,3 +43,14 @@ jobs:
       - name: Test
         run: deno task test
         timeout-minutes: 5
+
+  deno-test-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@main
+        with:
+          deno-version: ${{ env.DENO_VERSION }}
+
+      - name: Test Publish
+        run: deno task test:publish

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -6,8 +6,8 @@
     "fmt": "deno fmt denops",
     "lint": "deno lint denops",
     "lint-fix": "deno lint --fix denops",
-    "publish": "deno publish --dry-run --allow-dirty",
     "test": "deno test -A --doc --parallel --shuffle denops/**/*.ts",
+    "test:publish": "deno publish --dry-run --allow-dirty --set-version 0.0.0",
     "update": "deno outdated --recursive",
     "upgrade": "deno outdated --recursive --update"
   },

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,7 +1,7 @@
 {
   "lock": false,
   "tasks": {
-    "cache": "deno cache --reload denops/**/*.ts",
+    "cache": "deno install --reload",
     "check": "deno check denops/**/*.ts",
     "fmt": "deno fmt denops",
     "lint": "deno lint denops",

--- a/denops/ddu/deno.json
+++ b/denops/ddu/deno.json
@@ -1,6 +1,5 @@
 {
   "name": "@shougo/ddu-vim",
-  "version": "0.0.0",
   "exports": {
     "./action": "./base/action.ts",
     "./column": "./base/column.ts",


### PR DESCRIPTION
This PR improves the CI testing process and improve *deno.jsonc*.

The `version` field is automatically set by `@davit/publish-on-tag`, making it redundant.  The `--set-version` flag is now used in the `test:publish` task to handle testing.

The `publish` task has been renamed to `test:publish` to reflect its purpose as a test.  The primary focus of this PR is the enhancement of CI testing procedures.  Specifically, a new `deno-test-publish` job has been added to the `.github/workflows/deno.yml` file to test the publishing process within the CI pipeline.

Additionally, the deprecated `deno cache` command has also been removed and changed to `deno install`.